### PR TITLE
feat(cache): support separate binary compile cache on browser [ON HOLD]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2335,6 +2335,11 @@
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true
     },
+    "dexie": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-2.0.1.tgz",
+      "integrity": "sha1-ptxOYHRhxNpfk0YhkXoqiTmhjpc="
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2336,9 +2336,9 @@
       "dev": true
     },
     "dexie": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/dexie/-/dexie-2.0.1.tgz",
-      "integrity": "sha1-ptxOYHRhxNpfk0YhkXoqiTmhjpc="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-2.0.4.tgz",
+      "integrity": "sha512-aQ/s1U2wHxwBKRrt2Z/mwFNHMQWhESerFsMYzE+5P5OsIe5o1kgpFMWkzKTtkvkyyEni6mWr/T4HUJuY9xIHLA=="
     },
     "diff": {
       "version": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "typescript": "^2.9.2"
   },
   "dependencies": {
+    "dexie": "^2.0.1",
     "getroot": "^1.0.0",
     "tslib": "^1.9.2"
   },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "typescript": "^2.9.2"
   },
   "dependencies": {
-    "dexie": "^2.0.1",
+    "dexie": "^2.0.4",
     "getroot": "^1.0.0",
     "tslib": "^1.9.2"
   },

--- a/src/binaryCache.ts
+++ b/src/binaryCache.ts
@@ -1,0 +1,143 @@
+import Dexie from 'dexie';
+import { root } from 'getroot';
+import { ENVIRONMENT } from './environment';
+import { log } from './util/logger';
+
+interface BinaryCacheMetadata {
+  /**
+   * Wasm name to lookup in cache.
+   */
+  name: string;
+  /**
+   * Version of binary to lookup in cache.
+   */
+  version: string;
+}
+
+/**
+ * Browser specific metadata
+ */
+interface BinaryFileMetadata {
+  /**
+   * Wasm binary file name to load.
+   * Emscripten preamble does have hardcode this file name when build, but does not expose
+   * to generated module to access it but calls internally only with `locateFile` override.
+   *
+   * This property workaround those when calling instantiateWasm.
+   */
+  filename: string;
+  /**
+   *  path to wasm / asm binary (.wasm, .mem). If not specified, it'll try best guess via __dirname
+   */
+  locationPath?: string;
+}
+
+/**
+ * Browser specific metadata
+ */
+interface BinaryEndpointMetadata {
+  /**
+   * Endpoint to server to download binary module on browser
+   */
+  endpoint: string;
+}
+
+type BinaryMetadata = Partial<BinaryCacheMetadata> & (BinaryFileMetadata | BinaryEndpointMetadata);
+
+interface CachedBinary {
+  name: string;
+  version: string;
+  binaryBlob: any;
+}
+
+const getBinaryCache: () => Dexie & { modules: Dexie.Table<CachedBinary, number> } = () => {
+  //tslint:disable-next-line:no-require-imports
+  const dexieModule = require('dexie');
+  const dexieFactory = (dexieModule.default || dexieModule) as typeof Dexie;
+  const db = new dexieFactory('emscripte-wasm-loader-cache');
+
+  //set auto incremented id as primary key, and name / version property as queryable.
+  db.version(1).stores({ modules: '++id, name, version' });
+  return db as any;
+};
+
+/**
+ * Read wasm binary from specified endpoint, construct resultObject by instantiate it.
+ * This is stripped / simplifed flow of original wasm instntiation in preamble,
+ * (https://github.com/kripken/emscripten/blob/78b44ed55cc4d0b4d79f62df9e80ae6f29a5345b/src/preamble.js#L2116)
+ *
+ * as once override `instantiateWasm` it doesn't execute existing preamble instntiation anymore.
+ */
+const compileBinary = async (metadata: BinaryMetadata & { environment: ENVIRONMENT },
+                             importObject: any) => {
+  const { environment } = metadata;
+  const { locateFile, readBinary } = importObject.parent;
+
+  //In case of nodejs with if specified locateFile override, use filesystem to read binary
+  if (environment === ENVIRONMENT.NODE && locateFile) {
+    const { filename } = metadata as BinaryFileMetadata;
+    try {
+      const filePath = locateFile(filename);
+      return await root.WebAssembly.instantiate(readBinary(filePath), importObject);
+    } catch (error) {
+      log(`downloadBinary: could not load binary from ${filename}`, { error });
+    }
+  } else {
+    //For browser, we do fetch from specified endpoint and do streaming instantiation
+    const { endpoint } = metadata as BinaryEndpointMetadata;
+    return await root.WebAssembly.instantiateStreaming(root.fetch(endpoint, { credentials: 'same-origin' }), importObject);
+  }
+  return null;
+};
+
+/**
+ * Instantiate wasm binary, returns instantiated resultObject.
+ * If binary blod is not cached in binaryCache, it'll fetch / read binary and cache it
+ */
+const instantiateBinary = (metadata: BinaryMetadata & { environment: ENVIRONMENT },
+                           importObject: any) => {
+  const dexie = getBinaryCache();
+  const { name, version } = metadata;
+
+  return dexie.transaction('rw', dexie.modules, async () => {
+    const cachedBinaryCollection = await dexie.modules.where({ name: name!, version: version! });
+    const cachedBinary = await cachedBinaryCollection.toArray();
+
+    //found cached blob
+    if (cachedBinary.length === 1) {
+      log(`instantiateBinary: found cached blob for '${name}:${version}'`);
+      return await root.WebAssembly.instantiate(cachedBinary[0].binaryBlob, importObject);
+    }
+
+    //something went off, clear existing entires
+    if (cachedBinary.length > 1) {
+      log(`instantiateBinary: '${name}:${version}' have unexpected cache blobs, clearing existing blobs and instantiate new one`);
+      await cachedBinaryCollection.delete();
+    }
+
+    //cannot lookup cache for corresponding version, do first time compilation
+    const resultObject = await compileBinary(metadata, importObject);
+    if (!!resultObject) {
+      //got compiled resultobject, now cache it
+      await dexie.modules.add({ name: name!, version: version!, binaryBlob: resultObject.module });
+
+      //delete old version of cache if exists. Allow up to 3 historical binaries.
+      const updatedCachedBinaries = await dexie.modules.where({ name: name! }).sortBy('id');
+      if (updatedCachedBinaries.length > 3) {
+        const binaryVersionToDelete = updatedCachedBinaries.slice(0, updatedCachedBinaries.length - 3).map((x) => x.version);
+        await dexie.modules.where({ name: name! }).filter((x) => (binaryVersionToDelete as any).includes(x.version)).delete();
+
+        log(`instantiateBinary: deleted old binaries for ${name}`, { binaryVersionToDelete });
+      }
+    } else {
+      log(`instantiateBinary: could not read resultobject from wasm binary`);
+    }
+
+    return resultObject;
+  }).catch((reason) => {
+    log(`instantiateBinary: binaryCache transaction wasn't successul, trying to fall back clean instantiate`, { reason });
+    return compileBinary(metadata, importObject);
+  });
+};
+
+export { BinaryCacheMetadata, BinaryEndpointMetadata, BinaryFileMetadata, BinaryMetadata, CachedBinary, instantiateBinary };

--- a/src/constructModule.ts
+++ b/src/constructModule.ts
@@ -1,6 +1,12 @@
 import { ENVIRONMENT } from './environment';
 import { log } from './util/logger';
 
+interface BinaryMetadata {
+  endpoint: string;
+  name?: string;
+  version?: number;
+}
+
 type StringMap = { [key: string]: any };
 
 /**
@@ -27,7 +33,7 @@ interface AsmRuntimeType {
  *
  * @returns {StringMap} Augmented object with prefilled interfaces.
  */
-const constructModule = (value: StringMap, environment: ENVIRONMENT) => {
+const constructModule = (value: StringMap, environment: ENVIRONMENT, binaryMetadata?: BinaryMetadata) => {
   const ret = {
     ...value,
     __asm_module_isInitialized__: false,
@@ -64,7 +70,19 @@ const constructModule = (value: StringMap, environment: ENVIRONMENT) => {
     });
   };
 
+  //Wasm module have separate wasm binary file to load
+  if (!!binaryMetadata) {
+    log(`constructModule: construct custom binary file load for ${JSON.stringify(binaryMetadata)}`);
+
+    //Allow cache compiled binary results for browser environment where indexedDB is available
+    const isCacheStorageAccessible = !!indexedDB && !!binaryMetadata.version;
+
+    if (isCacheStorageAccessible) {
+      log(`constructModule: cache storage is accesible`);
+    }
+  }
+
   return ret as AsmRuntimeType;
 };
 
-export { StringMap, AsmRuntimeType, constructModule };
+export { BinaryMetadata, StringMap, AsmRuntimeType, constructModule };

--- a/src/constructModule.ts
+++ b/src/constructModule.ts
@@ -3,6 +3,7 @@ import { log } from './util/logger';
 
 interface BinaryMetadata {
   endpoint: string;
+  asmDir: string;
   name?: string;
   version?: number;
 }
@@ -74,11 +75,17 @@ const constructModule = (value: StringMap, environment: ENVIRONMENT, binaryMetad
   if (!!binaryMetadata) {
     log(`constructModule: construct custom binary file load for ${JSON.stringify(binaryMetadata)}`);
 
+    const { name, version, asmDir } = binaryMetadata;
     //Allow cache compiled binary results for browser environment where indexedDB is available
-    const isCacheStorageAccessible = !!indexedDB && !!binaryMetadata.version;
+    const isCacheStorageAccessible = !!indexedDB && !!name && !!version;
 
     if (isCacheStorageAccessible) {
-      log(`constructModule: cache storage is accesible`);
+      //noop
+    } else if (environment === ENVIRONMENT.NODE) {
+      const locateDir = asmDir || __dirname;
+      log(`constructModule: binaryEndpoint found, setting locateFile for loading wasm binary from ${locateDir}`);
+      //tslint:disable-next-line:no-require-imports
+      ret.locateFile = (fileName: string) => require('path').join(locateDir, fileName);
     }
   }
 

--- a/src/getModuleLoader.ts
+++ b/src/getModuleLoader.ts
@@ -1,4 +1,5 @@
-import { AsmRuntimeType, BinaryMetadata, constructModule, StringMap } from './constructModule';
+import { BinaryMetadata } from './binaryCache';
+import { AsmRuntimeType, constructModule, StringMap } from './constructModule';
 import { ENVIRONMENT } from './environment';
 import { isNode } from './util/isNode';
 import { log } from './util/logger';
@@ -10,7 +11,7 @@ import { log } from './util/logger';
  * This option is mostly for Electron's renderer process, which is detected as node.js env by default
  * but in case of would like to use fetch to download binary module.
  *
- * @param {BinaryMetadata} [binaryMetadata] Allow to specify separate wasm binary to load.
+ * @param {BinaryCacheMetadata} [binaryMetadata] Allow to specify separate wasm binary to load.
  * If this isn't specified, wasm should be compiled with SINGLE_FILE option.
  *
  * @returns {T}
@@ -74,4 +75,4 @@ const getModuleLoader: getModuleLoaderType = <T, R extends AsmRuntimeType>(
   }
 };
 
-export { BinaryMetadata, runtimeModuleType, moduleLoaderType, getModuleLoaderType, getModuleLoader };
+export { runtimeModuleType, moduleLoaderType, getModuleLoaderType, getModuleLoader };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { StringMap, AsmRuntimeType } from './constructModule';
+export { StringMap, AsmRuntimeType, BinaryMetadata } from './constructModule';
 export { ENVIRONMENT } from './environment';
 export { runtimeModuleType, moduleLoaderType, getModuleLoaderType, getModuleLoader } from './getModuleLoader';
 export { enableLogger, log } from './util/logger';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
-export { StringMap, AsmRuntimeType, BinaryMetadata } from './constructModule';
+export { StringMap, AsmRuntimeType } from './constructModule';
 export { ENVIRONMENT } from './environment';
+export { BinaryMetadata } from './binaryCache';
 export { runtimeModuleType, moduleLoaderType, getModuleLoaderType, getModuleLoader } from './getModuleLoader';
 export { enableLogger, log } from './util/logger';
 export { isNode } from './util/isNode';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,10 +14,10 @@
     "importHelpers": true,
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "es5",
+    "target": "es2017",
     "outDir": "dist",
     "lib": [
-      "es2016",
+      "es2017",
       "dom"
     ]
   },


### PR DESCRIPTION
For modules having separate wasm binary file on browser environment (where indexeddb is supported), cache compiled wasm binary for faster reload.

Chromimum (and Electron) seems doesn't completely support wasm structured cloning, which makes this feature always fall back to compile wasm binary everytime. Until sort out browser api support, holding this PR for now.