### PR TITLE
Upgrade nanoid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6900,9 +6900,9 @@
       "optional": true
     },
     "nanoid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.3.tgz",
-      "integrity": "sha512-NbaoqdhIYmY6FXDRB4eYtDVC9Z9eCbn8TyaiC16LNKtpPv/aqa0tOPD8y6gNE4yUNnaZ7LLhYtXOev/6+cBtfw=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA=="
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "getroot": "^1.0.0",
-    "nanoid": "^2.0.3",
+    "nanoid": "^3.2.0",
     "unixify": "^1.0.0"
   },
   "engines": {

--- a/spec/path/mountBuffer-spec.ts
+++ b/spec/path/mountBuffer-spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import * as nanoid from 'nanoid';
+import { nanoid } from 'nanoid';
 import { isMounted } from '../../src/path/isMounted';
 import { mountBuffer } from '../../src/path/mountBuffer';
 

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -1,2 +1,1 @@
-declare module 'nanoid';
 declare module 'unixify';

--- a/src/path/mountBuffer.ts
+++ b/src/path/mountBuffer.ts
@@ -1,4 +1,4 @@
-import * as nanoid from 'nanoid';
+import { nanoid } from 'nanoid';
 import { FS } from '../BaseAsmModule';
 import { log } from '../util/logger';
 import { isMounted } from './isMounted';


### PR DESCRIPTION
nanoid has a [security vulnerability](https://github.com/advisories/GHSA-qrpm-p2h7-hrv2) in versions < 3.1.31. I took a shot at upgrading it based on [the nanoid v3 migration guide](https://github.com/ai/nanoid/releases/tag/3.0.0), and all seems to work fine.

After doing this work, I realized that https://github.com/kwonoj/emscripten-wasm-loader/pull/90 exists. Maybe it'd make sense to upgrade nanoid in that PR and then cherry pick the second commit in this PR (https://github.com/kwonoj/emscripten-wasm-loader/commit/063752845bac8ff519266121f2c68f34d380a23f) over to that one?